### PR TITLE
Add ion locking test

### DIFF
--- a/js-helpers/deploy.js
+++ b/js-helpers/deploy.js
@@ -102,7 +102,7 @@ const presets = {
     ],
     timelocks: [
       {
-        receiver: '0xb14d1a16f30dB670097DA86D4008640c6CcC2B76',  // Testing - Account 3
+        receiver: '0x90F79bf6EB2c4f870365E785982E1f101E93b906',  // Testing - Account 3
         portions: [
           {amount: weiPerEth.mul('1000'), releaseDate: blockTimeFromDate('27 Dec 2021 00:00:00 GMT')},
           {amount: weiPerEth.mul('1000'), releaseDate: blockTimeFromDate('28 Dec 2021 00:00:00 GMT')},
@@ -110,7 +110,7 @@ const presets = {
         ]
       },
       {
-        receiver: '0xF55D5df4fa26c454a5635B4697C2Acf92f55cfD8',  // Testing - Account 4
+        receiver: '0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65',  // Testing - Account 4
         portions: [
           {amount: weiPerEth.mul('5000'), releaseDate: blockTimeFromDate('27 Dec 2021 00:00:00 GMT')},
           {amount: weiPerEth.mul('5000'), releaseDate: blockTimeFromDate('28 Dec 2021 00:00:00 GMT')},


### PR DESCRIPTION
Will add more tests to this branch.

Had to replace receivers' default addresses for ion timelocks with the actual account 3 and 4 addresses found in hardhat's configuration (perhaps they changed?).